### PR TITLE
chore: Add a license and a project description

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,22 @@
+Copyright (c) 2020 Arnau Siches, Israel Fenor
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Onelo
+
+Onelo is an application to build a graph from a set of interconnected markdown
+files.
+
+---
+
+**This project is in a very early stage. Use it at your own risk**
+
+---
+
+
+## Licence
+
+The Onelo codebase is licensed under the [MIT licence](./LICENCE).


### PR DESCRIPTION
Adds an MIT licence and a thin readme.

We might want to consider a dual licence MIT/Apache 2 like projects such as [Cargo](https://github.com/rust-lang/cargo).