### PR TITLE
Storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "cc"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +69,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "hashbrown"
@@ -106,9 +124,35 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a245984b1b06c291f46e27ebda9f369a94a1ab8461d0e845e23f9ced01f5db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "memchr"
@@ -122,6 +166,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "regex",
+ "rusqlite",
 ]
 
 [[package]]
@@ -129,6 +174,12 @@ name = "os_str_bytes"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "proc-macro-error"
@@ -158,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]
@@ -193,6 +244,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "rusqlite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c78c3275d9d6eb684d2db4b2388546b32fdae0586c20a82f3905d21ea78b9ef"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "lru-cache",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,9 +272,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -264,6 +336,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 clap = "=3.0.0-beta.1"
 regex = "1"
+rusqlite = { version = "0.24", features = ["bundled", "functions", "limits", "load_extension"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,7 +8,7 @@ use std::include_str;
 use std::path::Path;
 
 /// Opens a SQLite database at the given path.
-pub fn connect(path: &Path) -> Result<Connection> {
+pub fn connect<P: AsRef<Path>>(path: P) -> Result<Connection> {
     let conn = Connection::open(path)?;
     // conn.pragma_update(None, "foreign_keys", &"off")?;
     conn.pragma_update(None, "journal_mode", &"wal")?;
@@ -17,7 +17,7 @@ pub fn connect(path: &Path) -> Result<Connection> {
 }
 
 /// WAL persists across connections, this ensures it is switched off.
-pub fn disconnect(conn: &Connection) -> Result<()> {
+pub fn clean(conn: &Connection) -> Result<()> {
     conn.pragma_update(None, "wal_checkpoint", &"restart")?;
     conn.pragma_update(None, "journal_mode", &"delete")?;
 
@@ -31,4 +31,42 @@ pub fn bootstrap(conn: &Connection) -> Result<()> {
     conn.execute_batch(&bootstrap)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::NO_PARAMS;
+
+    #[test]
+    fn bootstrap_cache() -> Result<()> {
+        let mut conn = connect(":memory:")?;
+
+        bootstrap(&conn)?;
+
+        let tx = conn.transaction()?;
+        let mut stmt = tx.prepare(
+            r#"
+            SELECT
+                name
+            FROM
+                sqlite_schema
+            WHERE
+                type = 'table'
+            ORDER BY 1;
+            "#,
+        )?;
+        let mut actual: Vec<String> = Vec::new();
+        let rows = stmt.query_map(NO_PARAMS, |row| row.get(0))?;
+
+        for row in rows {
+            actual.push(row?);
+        }
+
+        let expected = vec!["context", "source", "source_entry"];
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,34 @@
+//! Cache storage
+//!
+//! This module contains the cache implementation and helper functions.
+
+use super::context::Result;
+use rusqlite::Connection;
+use std::include_str;
+use std::path::Path;
+
+/// Opens a SQLite database at the given path.
+pub fn connect(path: &Path) -> Result<Connection> {
+    let conn = Connection::open(path)?;
+    // conn.pragma_update(None, "foreign_keys", &"off")?;
+    conn.pragma_update(None, "journal_mode", &"wal")?;
+
+    Ok(conn)
+}
+
+/// WAL persists across connections, this ensures it is switched off.
+pub fn disconnect(conn: &Connection) -> Result<()> {
+    conn.pragma_update(None, "wal_checkpoint", &"restart")?;
+    conn.pragma_update(None, "journal_mode", &"delete")?;
+
+    Ok(())
+}
+
+/// Sets up the cache schema.
+pub fn bootstrap(conn: &Connection) -> Result<()> {
+    let bootstrap = include_str!("./sql/bootstrap.sql");
+
+    conn.execute_batch(&bootstrap)?;
+
+    Ok(())
+}

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -1,10 +1,7 @@
+use crate::context::{Message, Result};
 use crate::files;
 use clap::Clap;
-use std::error::Error;
 use std::path::PathBuf;
-
-type Message = String;
-type Result<T, E = Box<dyn Error>> = std::result::Result<T, E>;
 
 /// Builds the onelo store.
 #[derive(Debug, Clap)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,13 @@
+//! This module contains helpers for managing contextual information to be tracked throught the
+//! process.
+
+use std::error::Error;
+use std::result::Result as StdResult;
+
+/// The message delivered to the user.
+///
+/// This value is typically used in CLI commands to communicate successful outcomes to the user.
+pub type Message = String;
+
+/// Tidy result alias.
+pub type Result<T, E = Box<dyn Error>> = StdResult<T, E>;

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -1,17 +1,16 @@
+use crate::context::Result;
 use regex::Regex;
 use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-type Result<T, E = Box<dyn Error>> = std::result::Result<T, E>;
-
 #[derive(Debug)]
 struct SplitError(String);
 
 impl fmt::Display for SplitError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Bad!")
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod cli;
+pub mod context;
 pub mod files;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod cli;
 pub mod context;
 pub mod files;

--- a/src/sql/bootstrap.sql
+++ b/src/sql/bootstrap.sql
@@ -1,0 +1,25 @@
+-- Contextual information such as the commit hash used for building the cache,
+-- the version of Onelo used, etc.
+CREATE TABLE IF NOT EXISTS context (
+    key   text NOT NULL PRIMARY KEY,
+    value text NOT NULL
+);
+
+-- The set of sources with their routes. Identifiers are expected to be used
+-- in source entries to compact the path.
+--
+-- Routes can be from the local filesystem or from remote sources such as a
+-- Git repository.
+CREATE TABLE IF NOT EXISTS source (
+    id        text NOT NULL PRIMARY KEY,
+    route     text NOT NULL,
+    timestamp datetime NOT NULL
+);
+
+-- The set of source entries found in the processed sources.
+CREATE TABLE IF NOT EXISTS source_entry (
+  id       text NOT NULL PRIMARY KEY,
+  checksum text NOT NULL,
+  content  blob NOT NULL,
+  title    text NOT NULL
+);


### PR DESCRIPTION
Adds SQLite as a dependency to handle the build cache.

The crate is `rusqlite` which allows for embedding SQLite which makes it convenient for self-contained binaries.

As part of adding this I extracted both `Message` and `Result` into a `context` module which can be extended later on with a central error.