### PR TITLE
Blake3 checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,10 +45,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blake3"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4f9586c9a3151c4b49b19e82ba163dd073614dd057e53c969e1a4db5b52720"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "crypto-mac",
+ "digest",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
@@ -82,6 +115,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +150,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hashbrown"
@@ -116,6 +184,12 @@ checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "indexmap"
@@ -194,8 +268,11 @@ dependencies = [
 name = "onelo"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
+ "blake3",
  "chrono",
  "clap",
+ "hex",
  "regex",
  "rusqlite",
 ]
@@ -300,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+
+[[package]]
 name = "syn"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +430,12 @@ dependencies = [
  "wasi",
  "winapi",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ path = "src/lib.rs"
 
 
 [dependencies]
+arrayvec = "0.5"
+blake3 = "0.3"
 chrono = "0.4"
 clap = "=3.0.0-beta.2"
+hex = "0.4"
 regex = "1"
 rusqlite = { version = "0.24", features = ["bundled", "functions", "limits", "load_extension"] }

--- a/src/artefact.rs
+++ b/src/artefact.rs
@@ -1,7 +1,6 @@
 //! This module is concerned with the unique content found in sources.
 
-// TODO: Promote to a Type that encodes the hashing algorithm e.g. Blake3
-pub type Checksum = String;
+use crate::checksum::Checksum;
 
 // TODO: We want to keep raw bytes here, so we can delay UTF-8 enforcement to when it's needed.
 /// A sequence of bytes for a piece of content.

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,147 @@
+//! This module is concerned with the artefact checksums.
+
+use arrayvec::ArrayString;
+use blake3::{self, Hash, OUT_LEN};
+use std::array::TryFromSliceError;
+use std::convert::TryInto;
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+
+/// The multihash code.
+pub type Code = u8;
+const BLAKE3: Code = 0x1e;
+
+pub type Byteset = [u8; OUT_LEN];
+pub type Hex = ArrayString<[u8; 64]>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Checksum {
+    code: Code,
+    hash: Hash,
+}
+
+impl Checksum {
+    /// Hashes the given bytes.
+    ///
+    /// If you need to cast a `Byteset` as a `Checksum` use the `From` implementations.
+    ///
+    /// ## Examples
+    pub fn new(input: &[u8]) -> Self {
+        Self {
+            code: BLAKE3,
+            hash: blake3::hash(input),
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.hash.as_bytes()
+    }
+
+    pub fn to_hex(&self) -> Hex {
+        self.hash.to_hex()
+    }
+
+    fn wrap(hash: Hash) -> Self {
+        Self {
+            code: BLAKE3,
+            hash: hash.into(),
+        }
+    }
+
+    pub fn unwrap(&self) -> Hash {
+        self.hash
+    }
+}
+
+impl From<Byteset> for Checksum {
+    #[inline]
+    fn from(bytes: [u8; OUT_LEN]) -> Self {
+        Self::wrap(bytes.into())
+    }
+}
+
+impl From<Checksum> for Byteset {
+    #[inline]
+    fn from(checksum: Checksum) -> Self {
+        checksum.hash.into()
+    }
+}
+
+impl fmt::Display for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:0x}{}", self.code, self.to_hex())
+    }
+}
+
+impl FromStr for Checksum {
+    type Err = ChecksumError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let hash_bytes = hex::decode(s)?;
+        // let hash_array: [u8; OUT_LEN] = hash_bytes[..].try_into()?;
+        let code: u8 = hash_bytes[0];
+        dbg!(&code);
+        let hash_array: [u8; OUT_LEN] = hash_bytes[1..].try_into()?;
+        let hash: Hash = hash_array.into();
+
+        Ok(Checksum::wrap(hash))
+    }
+}
+
+#[derive(Debug)]
+pub enum ChecksumError {
+    Bad,
+    UnexpectedLength,
+    Hex(hex::FromHexError),
+}
+
+impl fmt::Display for ChecksumError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChecksumError::Bad => write!(f, "bad"),
+            ChecksumError::Hex(err) => write!(f, "{}", err),
+            ChecksumError::UnexpectedLength => {
+                write!(f, "The given slice cannot be casted as a checksum")
+            }
+        }
+    }
+}
+
+impl Error for ChecksumError {}
+
+impl From<hex::FromHexError> for ChecksumError {
+    fn from(err: hex::FromHexError) -> Self {
+        ChecksumError::Hex(err)
+    }
+}
+
+impl From<TryFromSliceError> for ChecksumError {
+    fn from(_err: TryFromSliceError) -> Self {
+        ChecksumError::UnexpectedLength
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blake3_checksum() {
+        let actual = Checksum::new(b"onelo");
+        let expected = "1ecabe0427e7fdaa13ec1d49de58a6179a2ecb6dd6fd674261421949fab0acc525";
+
+        assert_eq!(actual.to_string(), expected);
+    }
+
+    #[test]
+    fn parse() -> Result<(), ChecksumError> {
+        let hex = "1ecabe0427e7fdaa13ec1d49de58a6179a2ecb6dd6fd674261421949fab0acc525";
+        let actual: Checksum = hex.parse()?;
+        let expected = Checksum::new(b"onelo");
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
+pub mod artefact;
 pub mod cache;
+pub mod checksum;
 pub mod cli;
-pub mod content;
 pub mod content_type;
 pub mod context;
 pub mod files;

--- a/src/source_entry.rs
+++ b/src/source_entry.rs
@@ -1,6 +1,6 @@
 //! This module is concerned with the source entries.
 
-use crate::content::Checksum;
+use crate::checksum::Checksum;
 use crate::content_type::{ContentType, ContentTypeError};
 use crate::source::{Id as SourceId, ParseIdError};
 use std::error::Error;


### PR DESCRIPTION
This PR implements a `Checksum` type using the [Blake3](https://github.com/BLAKE3-team/BLAKE3) hashing algorithm.

**Important**: The hexadecimal representation encodes the hashing algorithm using a [Multihash](https://github.com/multiformats/multicodec/blob/master/table.csv) code. This way, checksum hashes will be self-describing.

I haven't bothered implementing uvar given that we are only using a single code of known length and fits in a single `u8`, something for the future if we need it.